### PR TITLE
Fix format for timezones that aren't whole numbers

### DIFF
--- a/validation.lisp
+++ b/validation.lisp
@@ -541,23 +541,25 @@ FMT is a keyword symbol specifying which output format is used as follows
       (if (null timezone)
           (decode-universal-time (round utime))
           (decode-universal-time (round utime) timezone))
-    (declare (fixnum se mi ho da mo ye dw tz) (ignore dst))
+    (declare (fixnum se mi ho da mo ye dw) (rational tz) (ignore dst))
     (let ((month-name (aref +month-names+ (1- mo)))
-          (week-day-name (aref +week-days+ dw)))
+          (week-day-name (aref +week-days+ dw))
+          (tz-ho (truncate (abs tz)))
+          (tz-mi (* (rem (abs tz) 1) 60)))
       (ecase fmt
         (:iso
          (format
           out
-          "~4d-~2,'0d-~2,'0d ~2,'0d:~2,'0d:~2,'0d~:[~; ~:[+~;-~]~2,'0d~]"
-          ye mo da ho mi se timezone (< 0 tz) (abs tz)))
+          "~4d-~2,'0d-~2,'0d ~2,'0d:~2,'0d:~2,'0d~:[~; ~:[+~;-~]~2,'0d~2,'0d~]"
+          ye mo da ho mi se timezone (< 0 tz) tz-ho tz-mi))
         (:short
-         (format out "~4d-~2,'0d-~2,'0d ~2,'0d:~2,'0d~:[~; ~:[+~;-~]~2,'0d~]"
-                 ye mo da ho mi timezone (< 0 tz) (abs tz)))
+         (format out "~4d-~2,'0d-~2,'0d ~2,'0d:~2,'0d~:[~; ~:[+~;-~]~2,'0d~2,'0d~]"
+                 ye mo da ho mi timezone (< 0 tz) tz-ho tz-mi))
         (:rfc2822
          (format
           out
-          "~A, ~2,'0d ~a ~4d ~2,'0d:~2,'0d:~2,'0d~:[~; ~:[+~;-~]~2,'0d~]"
-          week-day-name da month-name ye ho mi se timezone (< 0 tz) (abs tz)))
+          "~A, ~2,'0d ~a ~4d ~2,'0d:~2,'0d:~2,'0d~:[~; ~:[+~;-~]~2,'0d~2,'0d~]"
+          week-day-name da month-name ye ho mi se timezone (< 0 tz) tz-ho tz-mi))
         (:http
          (format out "~A, ~2,'0d ~a ~4d ~2,'0d:~2,'0d:~2,'0d GMT"
                  week-day-name da month-name ye ho mi se))


### PR DESCRIPTION
For example, the timezone for IST is +05:30. While the formatting is messed up, SBCL also signals a condition because it is declared as a FIXNUM.

This PR fixes both of these issues.

One side effect of this fix is that timezones are always printed as four digits now as opposed to two digits earlier i.e. `"2017-11-28 05:44:43 -0500"` instead of `"2017-11-28 05:44:24 -05"` earlier. Both RFC 2822 and ISO 8601 allow this.

Where the timezone is not a whole number e.g. -11/2, it would get printed like this: `"2017-11-28 16:17:15 +0530"`.